### PR TITLE
Add include path to Icarus to avoid depending on directory structure

### DIFF
--- a/tests/address_device_test/test.v
+++ b/tests/address_device_test/test.v
@@ -1,8 +1,8 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     send_usb_address_device(8'h00, 8'h1e);
     `assert("new device address", dut.dev_addr, 7'h1e);
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/in_nak_test/test.v
+++ b/tests/in_nak_test/test.v
@@ -1,7 +1,7 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     send_usb_in(0, 1);
     expect_usb_nak();
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/simple_spi_in_test/test.v
+++ b/tests/simple_spi_in_test/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {8'h81, 8'h00}, 
@@ -23,4 +23,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/simple_spi_out_test/test.v
+++ b/tests/simple_spi_out_test/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer({8'hAB}, {8'h00}, 8);
 
@@ -13,4 +13,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_16_bytes/test.v
+++ b/tests/spi_in_test_16_bytes/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -23,4 +23,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_16_bytes_dataack_smash/test.v
+++ b/tests/spi_in_test_16_bytes_dataack_smash/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -27,4 +27,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_16_bytes_x4/test.v
+++ b/tests/spi_in_test_16_bytes_x4/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -76,4 +76,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_32_bytes/test.v
+++ b/tests/spi_in_test_32_bytes/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 
@@ -26,4 +26,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_4_bytes/test.v
+++ b/tests/spi_in_test_4_bytes/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 32'h00000000}, 
@@ -23,4 +23,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_64_bytes/test.v
+++ b/tests/spi_in_test_64_bytes/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 
@@ -45,4 +45,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_64_bytes_slow/test.v
+++ b/tests/spi_in_test_64_bytes_slow/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 
@@ -37,4 +37,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_combined_cmd_x2/test.v
+++ b/tests/spi_in_test_combined_cmd_x2/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 32'hcafeb0ba, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -27,4 +27,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_split_cmd/test.v
+++ b/tests/spi_in_test_split_cmd/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -29,4 +29,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_split_cmd_1/test.v
+++ b/tests/spi_in_test_split_cmd_1/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -29,4 +29,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_split_cmd_2/test.v
+++ b/tests/spi_in_test_split_cmd_2/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -29,4 +29,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_split_cmd_3/test.v
+++ b/tests/spi_in_test_split_cmd_3/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -29,4 +29,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_split_cmd_4/test.v
+++ b/tests/spi_in_test_split_cmd_4/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -29,4 +29,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_split_cmd_5/test.v
+++ b/tests/spi_in_test_split_cmd_5/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -29,4 +29,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_split_cmd_6/test.v
+++ b/tests/spi_in_test_split_cmd_6/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -29,4 +29,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_in_test_split_cmd_7/test.v
+++ b/tests/spi_in_test_split_cmd_7/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00, 8'h00}, 
@@ -29,4 +29,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_out_test_64_bytes/test.v
+++ b/tests/spi_out_test_64_bytes/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h01, 8'h02, 8'h03, 8'h04, 8'h05, 8'h06, 8'h07, 8'h08, 8'h09, 8'h0a, 8'h0b, 8'h0c, 8'h0d, 8'h0e, 8'h0f, 8'h10, 
@@ -43,4 +43,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_out_test_64_bytes_ack_smash/test.v
+++ b/tests/spi_out_test_64_bytes_ack_smash/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h01, 8'h02, 8'h03, 8'h04, 8'h05, 8'h06, 8'h07, 8'h08, 8'h09, 8'h0a, 8'h0b, 8'h0c, 8'h0d, 8'h0e, 8'h0f, 8'h10, 
@@ -49,4 +49,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/spi_out_test_64_bytes_slow/test.v
+++ b/tests/spi_out_test_64_bytes_slow/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     prepare_spi_xfer(
       /* MOSI */ {32'hcafebabe, 8'h01, 8'h02, 8'h03, 8'h04, 8'h05, 8'h06, 8'h07, 8'h08, 8'h09, 8'h0a, 8'h0b, 8'h0c, 8'h0d, 8'h0e, 8'h0f, 8'h10, 
@@ -36,4 +36,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"

--- a/tests/test.mk
+++ b/tests/test.mk
@@ -1,5 +1,5 @@
 test: test.v ../../common/*.v ../*.vh
-	iverilog -s top_tb -o test -c ../file_list.txt 
+	iverilog -I.. -s top_tb -o test -c ../file_list.txt 
 	./test
 
 clean:

--- a/tests/win10_enumeration_test/test.v
+++ b/tests/win10_enumeration_test/test.v
@@ -1,4 +1,4 @@
-`include "../top_tb_header.vh"
+`include "top_tb_header.vh"
   initial begin
     #1000000;
     send_usb_port_reset();
@@ -280,4 +280,4 @@
 
     $finish(0);
   end
-`include "../top_tb_footer.vh"
+`include "top_tb_footer.vh"


### PR DESCRIPTION
Removing the ../ includes makes it easier for tools (e.g. FuseSoC) which does not necessarily execute from the testcase directory