### PR TITLE
PoC: Add FuseSoC features

### DIFF
--- a/TinyFPGA-Bootloader.core
+++ b/TinyFPGA-Bootloader.core
@@ -138,6 +138,7 @@ targets:
   address_device_test: &tc
     default_tool : icarus
     filesets : [common, test_common, address_device_test]
+    parameters : [continue_on_fail]
     tools:
       modelsim:
         vlog_options : [-sv]
@@ -234,3 +235,9 @@ targets:
   win10_enumeration_test:
     <<: *tc
     filesets : [common, test_common, win10_enumeration_test]
+
+parameters:
+  continue_on_fail:
+    datatype    : bool
+    description : Continue instead of exit on failed assertions
+    paramtype   : vlogdefine

--- a/TinyFPGA-Bootloader.core
+++ b/TinyFPGA-Bootloader.core
@@ -36,6 +36,7 @@ filesets:
       - tests/top_tb_header.vh : {is_include_file : true}
       - tests/top_tb_footer.vh : {is_include_file : true}
     file_type : verilogSource
+    depend : [">=::vlog_tb_utils:1.1"]
 
   address_device_test:
     files : [tests/address_device_test/test.v : {file_type : verilogSource}]

--- a/tests/simple_spi_in_test/test.v
+++ b/tests/simple_spi_in_test/test.v
@@ -1,5 +1,16 @@
 `include "top_tb_header.vh"
   initial begin
+
+    //Tap generator needs to know the number of tests beforehand
+    vtg.set_numtests(3);
+
+    /* File name can be set here to have a unique name for each
+     target. Using this will however not allow run-time settings with
+     the --tapfile= command-line argument */
+    
+    //vtg.set_file("simple_spi_in_test.tap");
+     
+
     prepare_spi_xfer(
       /* MOSI */ {8'h81, 8'h00}, 
       /* MISO */ {8'h00, 8'h65}, 
@@ -10,17 +21,35 @@
     send_usb_data0({8'h81, 8'h00, 8'h01, 8'h00, 8'h01, 8'h01}, 6 * 8);
     expect_usb_ack();
 
+    /* We will only reach here if not the assert inside
+     expect_usb_ack triggered. This means that successful runs will
+     list all three ok lines in the tap file, while failed ones will
+     only display as many lines as we have reached.
+     
+     As an alternative, we could let expect_usb_ack and friends set 
+     an error signal instead of exit and use
+     vtg.write_tc("6 bytes sent and acknowledged", !error); to
+     continue running after a failed subtest. Of course, this only
+     makes sense if there is a point to keep running after one subtest
+     failed */
+
+    //Arbitrary chosen string as I don't really know what you test :)
+    vtg.ok("6 bytes sent and acknowledged");
+
     #10000000;
 
     send_usb_in(0, 1);
     expect_usb_data0({8'h65}, 8);
     send_usb_ack();
 
+    vtg.ok("1 bytes sent and acknowledged");
+
     #10000000;
 
     send_usb_in(0, 1);
     expect_usb_nak();
 
+    vtg.ok("Received nak");
     $finish(0);
   end
 `include "top_tb_footer.vh"

--- a/tests/top_tb_header.vh
+++ b/tests/top_tb_header.vh
@@ -21,10 +21,13 @@
         end
 
 module top_tb;
-    initial begin
-      $dumpfile("test.vcd");
-      $dumpvars(0, dut);
-    end
+    /* By instantiating vlog_tb_utils we get access to some
+     extra functionality that can be activated by plusargs at
+     runtime.
+     fusesoc run --target=simple_spi_in_test TinyFPGA-Bootloader --help
+     will list all available options. Refer to this for details
+     */
+    vlog_tb_utils vtu();
 
    /* Set a default name for the tap file.
     Doesn't necessarily have to be unique as each target

--- a/tests/top_tb_header.vh
+++ b/tests/top_tb_header.vh
@@ -1,9 +1,13 @@
 `timescale 1ps / 1ps
 
-`ifdef __ICARUS__
- `define finish_and_return(code) $finish_and_return(code)
+`ifdef continue_on_fail
+ `define finish_and_return(code) #0
 `else
- `define finish_and_return(code) $finish
+ `ifdef __ICARUS__
+  `define finish_and_return(code) $finish_and_return(code)
+ `else
+  `define finish_and_return(code) $finish
+ `endif
 `endif
 
 `define assert(msg, signal, value) \

--- a/tests/top_tb_header.vh
+++ b/tests/top_tb_header.vh
@@ -26,6 +26,16 @@ module top_tb;
       $dumpvars(0, dut);
     end
 
+   /* Set a default name for the tap file.
+    Doesn't necessarily have to be unique as each target
+    executes in a separate work directory
+    Filename specified here can be overridden with the
+    vtg.set_file("filename") function at compile-time
+    or with a plusarg at run time by adding --tapfile=filename
+    to the FuseSoC command line
+    */
+   vlog_tap_generator #("test.tap") vtg();
+
     reg clk_48mhz;
     reg reset = 0;
 


### PR DESCRIPTION
This is not intended to be merged right away, but serves more as a showcase of things that can be done by depending on different FuseSoC features and other FuseSoC-enabled cores, as I'm unfamiliar with the code and not sure what you would like.

First patch adds TAP file generation to one of the testcases. The changes are heavily commented to describe the different routes to take.

Second patch replaces the hardcoded VCD file generation with extended functionality from vlog_tb_utils. This also brings in timeout support and heartbeat timer

Third patch adds a compile-time parameter that allows assertions to be non-fatal.