### PR TITLE
Add missing packages to requirements of setup.py

### DIFF
--- a/programmer/setup.py
+++ b/programmer/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 setup(
   name = 'tinyprog',
   packages = find_packages(),
-  install_requires = ['pyserial'],
+  install_requires = ['pyserial', 'jsonmerge', 'intelhex'],
   version = '1.0.0',
   description = 'Programmer for FPGA boards using the TinyFPGA USB Bootloader (http://tinyfpga.com)',
   author = 'Luke Valenty',


### PR DESCRIPTION
Hello!

The `setup.py` file lacks `jsonmerge` and `intelhex` in the `install_requires` array,
so trying to install it will succeed, but tinyprog will not run.