### PR TITLE
Update tinyprog to match tinyprog 1.0.23 from PyPI

### DIFF
--- a/programmer/setup.py
+++ b/programmer/setup.py
@@ -11,7 +11,7 @@ setup(
         'packaging',
         'pyusb'
     ],
-    version = '1.0.22b1',
+    version = '1.0.23',
     description = 'Programmer for FPGA boards using the TinyFPGA USB Bootloader (http://tinyfpga.com)',
     author = 'Luke Valenty',
     author_email = 'luke@tinyfpga.com',


### PR DESCRIPTION
[`tinyprog 1.0.23`](https://pypi.org/project/tinyprog/1.0.23/) on PyPI has changes which do not seem to exist in https://github.com/tinyfpga/TinyFPGA-Bootloader/tree/master/programmer/tinyprog.  I've extracted `__init__.py` out of the [`tinyprog-1.0.23-py2-none-any.whl`](https://files.pythonhosted.org/packages/98/d3/5b68b7123bf8b750543df9da2a5678b940ccb229502190194a95264d40b8/tinyprog-1.0.23-py2-none-any.whl) file, and added it to this branch/pull request, along with a bump of the version number to match.

When installed from the `git` branch:

```
pip install "git+file:///src/tinyfpga/packages/TinyFPGA-Bootloader@tinyprog-1.0.23#egg=tinyprog&subdirectory=programmer" --upgrade
```

it appears to be able to program a TinyFPGA BX with different status messages from the 1.0.22b1 version currently in GitHub.

```
tinyprog --program-image build/tinyfpga_bx_base_lm32.minimal//image-gateware+bios+micropython.bin

    TinyProg CLI
    ------------
    Using device id 1d50:6130
    Only one board with active bootloader, using it.
    Programming /dev/ttyACM0 with build/tinyfpga_bx_base_lm32.minimal//image-gateware+bios+micropython.bin
    Programming at addr 028000
    Waking up SPI flash
    442884 bytes to program
    Programming and Verifying: 100%|█████████| 443k/443k [00:10<00:00, 40.4kB/s]
    Success!
```

In theory something similar would work to try [installing it directly from `git+https`](https://pip.pypa.io/en/stable/reference/pip_install/#git), but I haven't tried that myself as I just installed from the `git` repo I had checked out.

Ewen

```
(LX P=tinyfpga_bx.minimal F=micropython) ewen@parthenon:/src/fpga/litex-buildenv$ pip install "git+file:///src/tinyfpga/packages/TinyFPGA-Bootloader@tinyprog-1.0.23#egg=tinyprog&subdirectory=programmer" --upgrade
Collecting tinyprog from git+file:///src/tinyfpga/packages/TinyFPGA-Bootloader@tinyprog-1.0.23#egg=tinyprog&subdirectory=programmer
  Cloning file:///src/tinyfpga/packages/TinyFPGA-Bootloader (to revision tinyprog-1.0.23) to /tmp/pip-install-vmbf5433/tinyprog
Requirement not upgraded as not directly required: pyserial<4,>=3 in ./build/conda/lib/python3.6/site-packages (from tinyprog) (3.4)
Requirement not upgraded as not directly required: jsonmerge<2,>=1.4.0 in ./build/conda/lib/python3.6/site-packages (from tinyprog) (1.5.2)
Requirement not upgraded as not directly required: intelhex<3,>=2.2.1 in ./build/conda/lib/python3.6/site-packages (from tinyprog) (2.2.1)
Requirement not upgraded as not directly required: tqdm<5,>=4.19.5 in ./build/conda/lib/python3.6/site-packages (from tinyprog) (4.29.0)
Requirement not upgraded as not directly required: six in ./build/conda/lib/python3.6/site-packages (from tinyprog) (1.11.0)
Requirement not upgraded as not directly required: packaging in ./build/conda/lib/python3.6/site-packages/packaging-17.1-py3.6.egg (from tinyprog) (17.1)
Requirement not upgraded as not directly required: pyusb in ./build/conda/lib/python3.6/site-packages (from tinyprog) (1.0.2)
Requirement not upgraded as not directly required: jsonschema<3.0.0 in ./build/conda/lib/python3.6/site-packages (from jsonmerge<2,>=1.4.0->tinyprog) (2.6.0)
Requirement not upgraded as not directly required: pyparsing>=2.0.2 in ./build/conda/lib/python3.6/site-packages/pyparsing-2.2.0-py3.6.egg (from packaging->tinyprog) (2.2.0)
Building wheels for collected packages: tinyprog
  Running setup.py bdist_wheel for tinyprog ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-3z_9b7cv/wheels/ae/af/fa/64759e6c52af34ee04f49108444b736914d073ac1900bb2355
Successfully built tinyprog
Installing collected packages: tinyprog
  Found existing installation: tinyprog 1.0.22b1
    Uninstalling tinyprog-1.0.22b1:
      Successfully uninstalled tinyprog-1.0.22b1
Successfully installed tinyprog-1.0.23
You are using pip version 10.0.1, however version 18.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
(LX P=tinyfpga_bx.minimal F=micropython) ewen@parthenon:/src/fpga/litex-buildenv$
```