### PR TITLE
setup.py: generate single line description=

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,12 @@ stages:
 install:
  - git fetch --tags
  - cd programmer
+ - pip install --upgrade pip
  - pip install --upgrade tox
+ - pip install --upgrade setuptools
  - pip install --upgrade setuptools_scm
+ - pip install --upgrade wheel
+ - pip install --upgrade twine
 
 script:
  - tox

--- a/programmer/setup.py
+++ b/programmer/setup.py
@@ -60,10 +60,10 @@ setup(
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3'
-        'Programming Language :: Python :: 3.5'
-        'Programming Language :: Python :: 3.6'
-        'Programming Language :: Python :: 3.7'
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
     entry_points={'console_scripts': ['tinyprog = tinyprog.__main__:main']},
 )

--- a/programmer/setup.py
+++ b/programmer/setup.py
@@ -18,6 +18,13 @@ except subprocess.CalledProcessError as e:
 with open("README.md", "rb") as fh:
     long_description = fh.read().decode('utf-8')
 
+short_description = """
+Programmer for FPGA boards using the TinyFPGA USB Bootloader
+ (http://tinyfpga.com).
+""".replace("\n", "").replace("\r", "").strip()
+# short description should not have newlines or start/ending spaces.
+assert len(short_description.splitlines()) == 1
+
 setup(
     name='tinyprog',
     packages=find_packages(),
@@ -31,10 +38,7 @@ setup(
         'git_describe_command': GIT_DESCRIBE_CMD,
     },
     setup_requires=['setuptools_scm'],
-    description="""\
-Programmer for FPGA boards using the TinyFPGA USB Bootloader
-(http://tinyfpga.com).
-""",
+    description=short_description,
     long_description=long_description,
     long_description_content_type="text/markdown",
     author='Luke Valenty',


### PR DESCRIPTION
@mithro, the Summary: field (from description=) needs to be a single line, so
replace newlines with spaces, and strip trailing white space.

Existing PyPI `PKG-INFO` has:

```
ewen@parthenon:/tmp/tinyprog-dev/EGG-INFO$ head -8 PKG-INFO 
Metadata-Version: 2.1
Name: tinyprog
Version: 1.0.24.dev16
Summary: Programmer for FPGA boards using the TinyFPGA USB Bootloader
(http://tinyfpga.com).

Home-page: https://github.com/tinyfpga/TinyFPGA-Bootloader/
Author: Luke Valenty
ewen@parthenon:/tmp/tinyprog-dev/EGG-INFO$ 
```

but AFAICT we need:

```
ewen@parthenon:/tmp/tinyprog/tinyprog-1.0.24.dev15+g74ae5c0.d20190118$ head -8 PKG-INFO 
Metadata-Version: 2.1
Name: tinyprog
Version: 1.0.24.dev15+g74ae5c0.d20190118
Summary: Programmer for FPGA boards using the TinyFPGA USB Bootloader (http://tinyfpga.com).
Home-page: https://github.com/tinyfpga/TinyFPGA-Bootloader/
Author: Luke Valenty
Author-email: luke@tinyfpga.com
License: GPLv3+
ewen@parthenon:/tmp/tinyprog/tinyprog-1.0.24.dev15+g74ae5c0.d20190118$ 
```

as generated when we strip out these stray newlines in the `description=` values.

`python setup.py sdist` seems to produce sensible looking `PKG-INFO` now, but I've obviously not tried uploading this to PyPI.  At minimum I think it should be *better* than now.

Ewen