### PR TITLE
Small fixes for version handling

### DIFF
--- a/programmer/tinyprog/__init__.py
+++ b/programmer/tinyprog/__init__.py
@@ -18,7 +18,7 @@ try:
     __version__ = get_distribution(__name__).version
 except DistributionNotFound:
     # package is not installed
-    pass
+    __version__ = "unknown"
 
 try:
     from .full_version import __full_version__

--- a/programmer/tinyprog/__init__.py
+++ b/programmer/tinyprog/__init__.py
@@ -22,8 +22,9 @@ except DistributionNotFound:
 
 try:
     from .full_version import __full_version__
-    assert __full_version__
-except (ImportError, AssertionError):
+    if not __full_version__:
+        raise ValueError
+except (ImportError, ValueError):
     __full_version__ = "unknown"
 
 


### PR DESCRIPTION
This adds a few small fixes for version handling.
It replaces the use of assert with explicit exeptions, because assert is not available with -O.
It also fixes a crash, if tinyprog is not installed in the system.