### PR TITLE
Program full sectors, longer read/write timeouts

### DIFF
--- a/programmer/.gitignore
+++ b/programmer/.gitignore
@@ -9,6 +9,10 @@ __pycache__/
 *~
 tinyprog/full_version.py
 
+# due to pip install . (for development)
+# https://github.com/pypa/pip/issues/6213
+pip-wheel-metadata
+
 # due to using tox and pytest
 .tox
 .coverage

--- a/programmer/tinyprog/__init__.py
+++ b/programmer/tinyprog/__init__.py
@@ -113,9 +113,20 @@ class SerialPort(object):
         return self.port_name
 
     def __enter__(self):
+        # Timeouts:
+        # - Read:  2.0 seconds (timeout)
+        # - Write: 5.0 seconds (writeTimeout)
+        #
+        # Rationale: hitting the writeTimeout is fatal, so it pays to be
+        # patient in case there is a brief delay; readTimeout is less
+        # fatal, but can result in short reads if it is hit, so we want
+        # a timeout high enough that is never hit normally.  In practice
+        # 1.0 seconds is *usually* enough, so the chosen values are double
+        # and five times the "usually enough" values.
+        #
         try:
             self.ser = serial.Serial(
-                self.port_name, timeout=1.0, writeTimeout=1.0).__enter__()
+                self.port_name, timeout=2.0, writeTimeout=5.0).__enter__()
         except serial.SerialException as e:
             raise PortError("Failed to open serial port:\n%s" % str(e))
 


### PR DESCRIPTION
As diagnosed in https://github.com/timvideos/litex-buildenv/issues/137, there seems to be an issue with programming the TinyFPGA BX SPI flash with less than 256 octets (minor sector size).  In theory the SPI flash supports this (see [datasheet](https://datasheet.octopart.com/AT25SF041-SSHD-B-Adesto-Technologies-datasheet-62342976.pdf) pages 14-16), but in practice it always seems to fail.  It's unclear whether this is caused by a state machine issue in the TinyFPGA-Bootloader verilog, or some bug or unclear documentation in the SPI flash.  But since we've *already* erased the entire 256 octets (and on any subsequent write, we'll also erase the entire 256 octets) the simplest solution is to pad all minor sector writes out to a full 256 octets (with 0xff, which is what is read back after erase, as that hopefully saves one cycle of wear on the "unused" flash cells).

Also double the read timeouts (was 1.0 seconds, now 2.0 seconds), because the only way that pySerial will return a short read is if the readTimeout is hit, and there are multiple reports of users getting short reads and verify errors (and thus programming failures; some bricking their boards).  And substantially increase the writeTimeout (was 1.0 seconds, now 5.0 seconds) because `tinyprog` gives up immediately if there is a writeTimeout, which could lead to a partially programmed board (possibly one that is bricked), so it seems worth being more patient.  (IIRC there's another pull request around that retries the sector write if it times out/fails, but ISTR it's buried in a gigantic pull request that adds a whole other board, etc, and is against 6-12 month old code, so it is not easily merged directly.)

Seems to work for me, both images that are a multiple of 256 octets, and images that are *not* a multiple of 256 octets.  (See https://github.com/timvideos/litex-buildenv/issues/137 for the testing to demonstrate there was a problem; I re-ran the tests in https://github.com/timvideos/litex-buildenv/issues/137#issuecomment-493830552 to check this version was working.)

Programing output:

```
(LX P=tinyfpga_bx.minimal F=none R=default-target-tinyfpga-bx) ewen@parthenon:/src/fpga/litex-buildenv$ make clean; export FIRMWARE=none; make image-flash
[...]
tinyprog --program-image build/tinyfpga_bx_base_lm32.minimal//image-gateware+bios+none.bin

    TinyProg CLI
    ------------
    Using device id 1d50:6130
    Only one board with active bootloader, using it.

    Programming /dev/ttyACM0 with build/tinyfpga_bx_base_lm32.minimal//image-gateware+bios+none.bin
    Programming at addr 028000
    Waking up SPI flash
    180192 bytes to program
    Programming and Verifying: 180kB [00:04, 39.6kB/s]                          
    Success!

(LX P=tinyfpga_bx.minimal F=stub R=default-target-tinyfpga-bx) ewen@parthenon:/src/fpga/litex-buildenv$ make clean; export FIRMWARE=stub; make image-flash
[...]
tinyprog --program-image build/tinyfpga_bx_base_lm32.minimal//image-gateware+bios+stub.bin

    TinyProg CLI
    ------------
    Using device id 1d50:6130
    Only one board with active bootloader, using it.

    Programming /dev/ttyACM0 with build/tinyfpga_bx_base_lm32.minimal//image-gateware+bios+stub.bin
    Programming at addr 028000
    Waking up SPI flash
    203904 bytes to program
    Programming and Verifying: 205kB [00:05, 39.7kB/s]                          
    Success!

(LX P=tinyfpga_bx.minimal F=stub R=default-target-tinyfpga-bx) ewen@parthenon:/src/fpga/litex-buildenv$ make clean; export FIRMWARE=micropython; make gateware; scripts/build-micropython.sh; make image-flash
[...]
tinyprog --program-image build/tinyfpga_bx_base_lm32.minimal//image-gateware+bios+micropython.bin

    TinyProg CLI
    ------------
    Using device id 1d50:6130
    Only one board with active bootloader, using it.

    Programming /dev/ttyACM0 with build/tinyfpga_bx_base_lm32.minimal//image-gateware+bios+micropython.bin
    Programming at addr 028000
    Waking up SPI flash
    442884 bytes to program
    Programming and Verifying: 446kB [00:11, 40.3kB/s]                          
    Success!

(LX P=tinyfpga_bx.minimal F=micropython R=default-target-tinyfpga-bx) ewen@parthenon:/src/fpga/litex-buildenv$ 
```

And the serial output (note that if you program `FIRMWARE=none` it just writes to the gateware section of the flash, which pretty much guarantees it'll boot whatever firmware was written *previously*, thus in my case it booted MicroPython; see further down for writing a different firmware and then re-writing MicroPython back again):

```
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
 SoC BIOS / CPU: LM32 /  16MHz
(c) Copyright 2012-2018 Enjoy-Digital
(c) Copyright 2007-2018 M-Labs Limited
Built Jun  8 2019 12:59:13

BIOS CRC passed (494556cb)
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
Timeout
Booting from flash...
Executing booted program at 0x20058008
MicroPython v1.9.4-534-gd2bd404 on 2019-05-20; litex with lm32
>>> 
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
 SoC BIOS / CPU: LM32 /  16MHz
(c) Copyright 2012-2018 Enjoy-Digital
(c) Copyright 2007-2018 M-Labs Limited
Built Jun  8 2019 13:03:17

BIOS CRC passed (f68ee6ca)
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
Timeout
Booting from flash...
Executing booted program at 0x20058008
Stub firmware booting...


LiteX-Buildenv Stub Firmware, built Jun  8 2019 13:03:18

Type "help" for help

STUB>
        __   _ __      _  __
       / /  (_) /____ | |/_/
      / /__/ / __/ -_)>  <
     /____/_/\__/\__/_/|_|
 SoC BIOS / CPU: LM32 /  16MHz
(c) Copyright 2012-2018 Enjoy-Digital
(c) Copyright 2007-2018 M-Labs Limited
Built Jun  8 2019 13:09:46

BIOS CRC passed (71f12f87)
Booting from serial...
Press Q or ESC to abort boot completely.
sL5DdSMmkekro
Timeout
Booting from flash...
Executing booted program at 0x20058008
MicroPython v1.9.4-534-gd2bd404 on 2019-06-08; litex with lm32
>>> 
```