### PR TITLE
tinyprog security page writing and other features

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Optionally, an additional `desc.tgz` file may be included in the SPI flash itsel
   "bver": "2.0.0",
   "update": "https://tinyfpga.com/update/tinyfpga-bx",
   "addrmap": {
-    "bootloader": "0x00000+131542",
-    "userimage":  "0x30000+131542",
-    "userdata":   "0x50000+710000",
-    "desc.tgz":   "0xFC000+16000"
+    "bootloader": "0x00000-0x2FFFF",
+    "userimage":  "0x30000-0x4FFFF",
+    "userdata":   "0x50000-0xFBFFF",
+    "desc.tgz":   "0xFC000-0xFFFFF"
   }
 }
 ```

--- a/programmer/tinyprog/__init__.py
+++ b/programmer/tinyprog/__init__.py
@@ -572,7 +572,7 @@ class TinyProg(object):
         self.progress("Waking up SPI flash")
         self.wake()
         self.progress("Erasing security page " + str(page))
-	self.erase_security_register_page(page)
+        self.erase_security_register_page(page)
         self.progress(str(len(data)) + " bytes to program")
-	return self.program_security_register_page(page, data)
+        return self.program_security_register_page(page, data)
 

--- a/programmer/tinyprog/__init__.py
+++ b/programmer/tinyprog/__init__.py
@@ -2,6 +2,7 @@ import json
 import platform
 import re
 import struct
+import time
 
 from functools import reduce
 from pkg_resources import get_distribution, DistributionNotFound
@@ -566,3 +567,12 @@ class TinyProg(object):
         self.wake()
         self.progress(str(len(bitstream)) + " bytes to program")
         return self.program_fast(addr, bitstream)
+
+    def program_security_page(self, page, data):
+        self.progress("Waking up SPI flash")
+        self.wake()
+        self.progress("Erasing security page " + str(page))
+	self.erase_security_register_page(page)
+        self.progress(str(len(data)) + " bytes to program")
+	return self.program_security_register_page(page, data)
+


### PR DESCRIPTION
When bootstrapping an FPGA dev board it is handy to have a way to write to the SFDP security pages. The `tinyprog` class had the `program_security_register_page` methods; this patch adds a command line argument to allow it to be called.

If there is no meta data in the SPI flash, it is still sometimes desirable to flash at a specific address with `-a`. This patch allows `-a` to force the address even if there is no meta data.

To speed up re-writing similar bitstreams, `tinyprog` now pre-reads the current contents and only does a sector erase if necessary.  Pages of entirely 0xFF are also not re-written after a sector erase.

Also updates the README with the new format for the `bootmeta`-`addrmap` struct.