### PR TITLE
Simulation fixes

### DIFF
--- a/TinyFPGA-Bootloader.core
+++ b/TinyFPGA-Bootloader.core
@@ -4,6 +4,7 @@ name : ::TinyFPGA-Bootloader:0
 filesets:
   common:
     files:
+      - common/strobe.v
       - common/usb_fs_out_arb.v
       - common/usb_reset_det.v
       - common/usb_serial_ctrl_ep.v

--- a/common/strobe.v
+++ b/common/strobe.v
@@ -19,8 +19,8 @@ module strobe(
 	initial begin
 		flag = 0;
 		prev_strobe = 0;
-		sync = 0;
-		data = 0;
+		sync[DELAY:0] = 0;
+		data[WIDTH-1:0] = 0;
 	end
 
 	// flip the flag and clock in the data when strobe is high
@@ -55,7 +55,7 @@ module dflip(
 );
 	reg [2:0] d;
 	initial begin
-		d = 0;
+		d[2:0] = 0;
 	end
 	always @(posedge clk)
 		d <= { d[1:0], in };

--- a/common/strobe.v
+++ b/common/strobe.v
@@ -16,6 +16,13 @@ module strobe(
 	reg [DELAY:0] sync;
 	reg [WIDTH-1:0] data;
 
+	initial begin
+		flag = 0;
+		prev_strobe = 0;
+		sync = 0;
+		data = 0;
+	end
+
 	// flip the flag and clock in the data when strobe is high
 	always @(posedge clk_in) begin
 		//if ((strobe_in && !prev_strobe)
@@ -47,6 +54,9 @@ module dflip(
 	output out
 );
 	reg [2:0] d;
+	initial begin
+		d = 0;
+	end
 	always @(posedge clk)
 		d <= { d[1:0], in };
 	assign out = d[2];

--- a/common/usb_fs_out_pe.v
+++ b/common/usb_fs_out_pe.v
@@ -160,65 +160,65 @@ module usb_fs_out_pe #(
       end
       always @* begin
 
-        ep_state_next[ep_num] <= ep_state[ep_num];
+        ep_state_next[ep_num] = ep_state[ep_num];
 
         if (out_ep_stall[ep_num]) begin
-          ep_state_next[ep_num] <= STALL;
+          ep_state_next[ep_num] = STALL;
 
         end else begin
           case (ep_state[ep_num])
             READY_FOR_PKT : begin
               if (out_xfr_start && rx_endp == ep_num) begin
-                ep_state_next[ep_num] <= PUTTING_PKT;
+                ep_state_next[ep_num] = PUTTING_PKT;
 
               end else begin
-                ep_state_next[ep_num] <= READY_FOR_PKT;
+                ep_state_next[ep_num] = READY_FOR_PKT;
               end
             end
 
             PUTTING_PKT : begin
               if (new_pkt_end && current_endp == ep_num) begin
-                ep_state_next[ep_num] <= GETTING_PKT;
+                ep_state_next[ep_num] = GETTING_PKT;
 
               end else if (rollback_data && current_endp == ep_num) begin
-                ep_state_next[ep_num] <= READY_FOR_PKT;
+                ep_state_next[ep_num] = READY_FOR_PKT;
 
               end else begin
-                ep_state_next[ep_num] <= PUTTING_PKT;
+                ep_state_next[ep_num] = PUTTING_PKT;
               end
             end
 
             GETTING_PKT : begin
 
               if (ep_get_addr[ep_num][5:0] >= (ep_put_addr[ep_num][5:0] - 2)) begin
-                ep_state_next[ep_num] <= READY_FOR_PKT;
+                ep_state_next[ep_num] = READY_FOR_PKT;
 
               end else begin
-                ep_state_next[ep_num] <= GETTING_PKT;
+                ep_state_next[ep_num] = GETTING_PKT;
               end
             end
 
             STALL : begin
               if (setup_token_received && rx_endp == ep_num) begin
-                ep_state_next[ep_num] <= READY_FOR_PKT;
+                ep_state_next[ep_num] = READY_FOR_PKT;
 
               end else begin
-                ep_state_next[ep_num] <= STALL;
+                ep_state_next[ep_num] = STALL;
               end
             end
 
             default begin
-              ep_state_next[ep_num] <= READY_FOR_PKT;
+              ep_state_next[ep_num] = READY_FOR_PKT;
             end
           endcase
         end
 
         if (ep_state_next[ep_num][1:0] == READY_FOR_PKT) begin
-          ep_get_addr_next[ep_num][5:0] <= 0;
+          ep_get_addr_next[ep_num][5:0] = 0;
         end else if (ep_state_next[ep_num][1:0] == GETTING_PKT && out_ep_data_get[ep_num]) begin
-          ep_get_addr_next[ep_num][5:0] <= ep_get_addr[ep_num][5:0] + 1;
+          ep_get_addr_next[ep_num][5:0] = ep_get_addr[ep_num][5:0] + 1;
         end else begin
-          ep_get_addr_next[ep_num][5:0] <= ep_get_addr[ep_num][5:0];
+          ep_get_addr_next[ep_num][5:0] = ep_get_addr[ep_num][5:0];
         end
       end
 

--- a/common/usb_fs_out_pe.v
+++ b/common/usb_fs_out_pe.v
@@ -152,6 +152,12 @@ module usb_fs_out_pe #(
   genvar ep_num;
   generate
     for (ep_num = 0; ep_num < NUM_OUT_EPS; ep_num = ep_num + 1) begin
+      initial begin
+        ep_state_next[ep_num] = READY_FOR_PKT;
+        ep_state[ep_num] = READY_FOR_PKT;
+        ep_get_addr_next[ep_num] = 0;
+        ep_get_addr[ep_num] = 0;
+      end
       always @* begin
 
         ep_state_next[ep_num] <= ep_state[ep_num];

--- a/common/usb_fs_tx.v
+++ b/common/usb_fs_tx.v
@@ -44,6 +44,9 @@ module usb_fs_tx (
   // convert tx_data_get from 48 to clk
   //wire tx_data_get_48 = tx_data_get;
   reg tx_data_get_48;
+  initial begin
+    tx_data_get_48 = 0;
+  end
   strobe tx_data_get_strobe(
 	.clk_in(clk_48mhz),
 	.clk_out(clk),

--- a/tests/file_list.txt
+++ b/tests/file_list.txt
@@ -1,4 +1,6 @@
 test.v
+../vlog_tb_utils/vlog_tb_utils.v
+../vlog_tb_utils/vlog_tap_generator.v
 ../../common/edge_detect.v
 ../../common/strobe.v
 ../../common/tinyfpga_bootloader.v


### PR DESCRIPTION
This PR fixes #51:
* adds missing files to both filelist and fusesoc core definition
* fixes simulation hangs by adding initial register values and switching to blocking assignments in combinational logic generation.

However, I see some errors in the simulation:

```
fusesoc --cores-root `pwd` run --run --target win10_enumeration_test TinyFPGA-Bootloader --vcd --timescale="1ps / 1ps" --continue_on_fail
INFO: Preparing ::vlog_tb_utils:1.1                                                                                                                                                                                                           
INFO: Preparing ::TinyFPGA-Bootloader:0                                                                                
INFO: Setting up project                                                                                                                                                                                                                      
                                                                                                                       
INFO: Running                                                                                                          
iverilog -stop_tb -c TinyFPGA-Bootloader_0.scr -o TinyFPGA-Bootloader_0                                                
vvp -n -M. -l icarus.log -lxt2  TinyFPGA-Bootloader_0 +vcd=1                                                           
VCD info: dumpfile testlog.vcd opened for output.                                                                      
LOCATION: ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:         25                                 
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:         32                                       
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:         37                                       
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:         57                                       
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:         91                                       
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        108                                                                                                                                                              
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        129                                       
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        147                                                                                                                                                              
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        180                                       
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        214                                       
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        219       
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        221                                                                                                                                                              
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        224                                                                                                                                                              
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        228                                                                                                                                                              
          3033216064 ERROR (top_tb.expect_usb_data): data length. usb_tx_len != length + 24                                                                                                                                                   
    actual:   008                                                                                                                                                                                                                             
    expected: 00000018                                                                                                 
          3033216064 ERROR (top_tb.expect_usb_data): data mismatch. usb_tx_data != raw_usb_data                        
    actual:   00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
0000000000000000000000000000005a                                                                                       
    expected: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
0000000000000000000000000000004b                                                                                       
          3033216064 ERROR (top_tb.expect_usb_data): data pid mismatch. usb_tx_data[3:0] != pid                        
    actual:   a                                                                                                        
    expected: b                                            
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        230
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        234
          3057047872 ERROR (top_tb.expect_usb_data): data length. usb_tx_len != length + 24
    actual:   018                                          
    expected: 00000050                                     
          3057047872 ERROR (top_tb.expect_usb_data): data mismatch. usb_tx_data != raw_usb_data
    actual:   00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
0000000000000000000000000000004b
    expected: 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
0000000000000432080001000025804b
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        252
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        264
    ../src/TinyFPGA-Bootloader_0/tests/win10_enumeration_test/test.v:        282
```
looks like some IP responses are different from expected. Not sure if this is a bug in the IP or the test. @tinyfpga can you take a look on this?


