### PR TITLE
Fix program_security_page for python3

### DIFF
--- a/programmer/tinyprog/__main__.py
+++ b/programmer/tinyprog/__main__.py
@@ -479,7 +479,7 @@ try using libusb to connect to boards without a serial driver attached"""
                     print("    Programming %s security page with %s" % (
                         active_port, args.security))
 
-                    data = open(args.security, 'r').read()
+                    data = open(args.security, 'rb').read()
 
                     if args.addr is not None:
                         addr = parse_int(args.addr)


### PR DESCRIPTION
In python3 if you read from a file using 'r' you get strings, not bytes.
The API for programming expects bytes, so change accordingly.

This is the error:

```
[bluecmd0]$ python3 ~/TinyFPGA-Bootloader/programmer/tinyprog/__main__.py -a 1 --security boardmeta.json


    TinyProg CLI
    ------------
    Using device id 1d50:6130
    Only one board with active bootloader, using it.

    Programming /dev/ttyACM0 security page with boardmeta.json
    Waking up SPI flash
    Erasing security page 1
    96 bytes to program
Traceback (most recent call last):
  File "/home/bluecmd/TinyFPGA-Bootloader/programmer/tinyprog/__main__.py", line 515, in <module>
    main()
  File "/home/bluecmd/TinyFPGA-Bootloader/programmer/tinyprog/__main__.py", line 493, in main
    if not fpga.program_security_page(addr, data):
  File "/usr/local/lib/python3.7/dist-packages/tinyprog-0.1.dev146+gfbfa25d-py3.7.egg/tinyprog/__init__.py", line 598, in program_security_page
    return self.program_security_register_page(page, data)
  File "/usr/local/lib/python3.7/dist-packages/tinyprog-0.1.dev146+gfbfa25d-py3.7.egg/tinyprog/__init__.py", line 355, in program_security_register_page
    page << (8 + self.security_page_bit_offset), data)
  File "/usr/local/lib/python3.7/dist-packages/tinyprog-0.1.dev146+gfbfa25d-py3.7.egg/tinyprog/__init__.py", line 325, in cmd
    write_string = bytearray([opcode]) + addr + data
TypeError: can't concat str to bytearray
```