### PR TITLE
added vlog_tb_utils as a submodule, as it was missing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/vlog_tb_utils"]
+	path = tests/vlog_tb_utils
+	url = https://github.com/fusesoc/vlog_tb_utils


### PR DESCRIPTION
I noticed this was needed, when I tried to run the built-in test simulations. Took a little bit of searching to figure out that there was a missing submodule, and where it was.

All this does is add it back in as a submodule so that `git submodule init` then `git submodule update` will include it.