### PR TITLE
fix: missing metadata crowd supply hack

### DIFF
--- a/programmer/tinyprog/__init__.py
+++ b/programmer/tinyprog/__init__.py
@@ -3,6 +3,7 @@ import platform
 import re
 import struct
 import time
+import uuid
 
 from functools import reduce
 from pkg_resources import get_distribution, DistributionNotFound
@@ -214,6 +215,26 @@ class TinyMeta(object):
         self.prog = prog
         prog.wake()
         self.root = self._read_metadata()
+        if self.root is None:
+            self.root = {
+            "boardmeta": {
+                "hver": "0.0.0",
+                "name": "TinyFPGA BX",
+                "fpga": "ICE40LP8K-cm81",
+                "uuid": str(uuid.uuid4())
+            },
+            "bootmeta": {
+                "bver": "2.0.0",
+                "bootloader": "TinyFPGA USB Bootloader",
+                "update": "https://tinyfpga.com/update/tinyfpga-bx",
+                "addrmap": {
+                    "bootloader": "0x00000-0x28000",
+                    "userimage":  "0x28000-0x50000",
+                    "userdata":   "0x50000-0xFC000",
+                    "desc.tgz":   "0xFC000-0xFFFFF"
+                }
+            }
+        }
 
     def _parse_json(self, data):
         try:


### PR DESCRIPTION
This PR checks to see if the root metadata is missing.  If it is, it will provide a hard-coded version.  

Several attempts have been made to burn the metadata to the board but with no success. The section is write protected.  It  provides a solution for issue #72 and https://github.com/tinyfpga/TinyFPGA-BX/issues/37.  The right solution is for TinyFPGA to send out new boards to those that are affected by this missed metadata. 